### PR TITLE
Fix </a> closing before <img> in social links

### DIFF
--- a/src/components/SocialIcon.astro
+++ b/src/components/SocialIcon.astro
@@ -5,6 +5,7 @@ const { svg, alt, href } = Astro.props;
 <div
   class="ease bg-gradient-to-tl from-springGreen to-springGreen bg-invisibleSmall bg-left-bottom bg-no-repeat duration-300 hover:bg-visibleSmall"
 >
-  <a href={href} rel="noopener noreferrer" target="_blank"></a>
-  <img width="20px" height="20px" src={svg.src} alt={alt} />
+  <a href={href} rel="noopener noreferrer" target="_blank">
+    <img width="20px" height="20px" src={svg.src} alt={alt} />
+  </a>
 </div>


### PR DESCRIPTION
# Description

Fix </a> closing before <img> in social links

Fixes #33 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (config/trivial task)
- [ ] Documentation
